### PR TITLE
updates made for lab to run without 'CSRF errors'

### DIFF
--- a/server/djangobackend/settings.py
+++ b/server/djangobackend/settings.py
@@ -27,7 +27,9 @@ DEBUG = True
 
 APPEND_SLASH = True
 
-ALLOWED_HOSTS = ["localhost"]
+ALLOWED_HOSTS = ['localhost','<Your app URL>']
+
+CSRF_TRUSTED_ORIGINS = ['<Your app URL>']
 
 
 # Application definition
@@ -46,7 +48,6 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
Below updates  required to run the Week 5 K8S deployment lab correctly (without CSRF error)

1.  Below line has been removed

->  'django.middleware.csrf.CsrfViewMiddleware',

2. ALLOWED_HOSTS section - codes updated

3. CSRF_TRUSTED_ORIGINS section - code newly added